### PR TITLE
Add open graph meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
   <meta name="author" content="GrUSP - Teo Miscia">
   <meta name="generator" content="Hugo 0.81.0" />
   
+  <!-- Open Graph Meta Tags -->
+  <meta property="og:title" content="phpday PUG Edition 2021 by GrUSP" />
+  <meta property="og:description" content="Un evento online e gratuito di una giornata, organizzato dai PUG (PHP User Group) italiani." />
+  <meta property="og:image" content="https://pug.phpday.it/images/grusp/HeaderPhpDay.png" />
+  <meta property="og:url" content="https://pug.phpday.it/" />
+	
   <!-- Mobile Specific Metas -->
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Add open graph meta tags to simplify sharing the event on social media platforms